### PR TITLE
Add git-rebase alias to bash and zsh

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -124,11 +124,13 @@ alias go-tests='go test ./...'
 ## git ##
 alias git-push-all='for remote in `git remote`; do git push $remote; done'
 alias git-pull='git pull --recurse-submodules'
+alias git-rebase='bash ~/.scripts/util/git/rebase.sh'
 alias git-download='sh ~/.scripts/util/git/download.sh'
 
 ## yadm ##
 alias yadm-push-all='for remote in `yadm remote`; do yadm push $remote; done'
 alias yadm-pull='yadm pull --recurse-submodules'
+alias yadm-rebase='bash ~/.scripts/util/git/rebase.sh --yadm'
 
 ## QEMU ##
 alias qemu-mount='sudo sh ~/.scripts/util/qemu/qemu-mount.sh'

--- a/.zsh_aliases
+++ b/.zsh_aliases
@@ -122,11 +122,13 @@ alias go-tests='go test ./...'
 ## git ##
 alias git-push-all='for remote in `git remote`; do git push $remote; done'
 alias git-pull='git pull --recurse-submodules'
+alias git-rebase='bash ~/.scripts/util/git/rebase.sh'
 alias git-download='sh ~/.scripts/util/git/download.sh'
 
 ## yadm ##
 alias yadm-push-all='for remote in `yadm remote`; do yadm push $remote; done'
 alias yadm-pull='yadm pull --recurse-submodules'
+alias yadm-rebase='bash ~/.scripts/util/git/rebase.sh --yadm'
 
 ## QEMU ##
 alias qemu-mount='sudo sh ~/.scripts/util/qemu/qemu-mount.sh'


### PR DESCRIPTION
# Description

Add the `git-rebase` and `yadm-rebase` aliases to bash and zsh environments to point to the `~/.script/util/git/rebase.sh` utility script for dynamic rebasing.